### PR TITLE
Find bin folder as candidate

### DIFF
--- a/src/Runner/PHPStanRunner.php
+++ b/src/Runner/PHPStanRunner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PHPStanFixer\Runner;
 
+use PHPStanFixer\Util\AutoloadUtil;
 use Symfony\Component\Process\Process;
 
 class PHPStanRunner
@@ -65,10 +66,13 @@ class PHPStanRunner
 
     private function findPHPStan(): string
     {
+        $autoloadUtil = new AutoloadUtil();
+
         $candidates = [
             'vendor/bin/phpstan',
             '../vendor/bin/phpstan',
             '../../vendor/bin/phpstan',
+            $autoloadUtil->getBinFolder() . '/phpstan',
             'phpstan',
         ];
 

--- a/src/Util/AutoloadUtil.php
+++ b/src/Util/AutoloadUtil.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PHPStanFixer\Util;
+
+class AutoloadUtil
+{
+    private readonly string $composerPath;
+
+    public function __construct(?string $composerFile = null, ?string $projectRoot = null, private readonly bool $dev = true)
+    {
+        $this->composerPath = ($composerFile ?: trim(getenv('COMPOSER') ?: '')) ?: './composer.json';
+    }
+
+
+    public function getBinFolder(): string
+    {
+        if (! file_exists($this->composerPath)) {
+            throw new \RuntimeException('Unable to find composer.json');
+        }
+
+        $composerContent = file_get_contents($this->composerPath);
+
+        if ($composerContent === false) {
+            throw new \RuntimeException('Unable to read composer.json');
+        }
+
+        $composer = json_decode($composerContent, true);
+        if (! \is_array($composer)) {
+            throw new \RuntimeException('Invalid composer.json file');
+        }
+
+        return $composer['config']['bin-dir'] ?? 'vendor/bin';
+    }
+}

--- a/tests/Util/AutoloadUtilTest.php
+++ b/tests/Util/AutoloadUtilTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PHPStanFixer\Tests\Util;
+
+use PHPStanFixer\Util\AutoloadUtil;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class AutoloadUtilTest extends TestCase
+{
+    private string $tempComposerFile;
+
+    protected function setUp(): void
+    {
+        $this->tempComposerFile = tempnam(sys_get_temp_dir(), 'composer') . '.json';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->tempComposerFile)) {
+            unlink($this->tempComposerFile);
+        }
+    }
+
+    public function testGetBinFolderReturnsDefaultVendorBin(): void
+    {
+        file_put_contents($this->tempComposerFile, json_encode([]));
+        $autoloadUtil = new AutoloadUtil($this->tempComposerFile);
+
+        $this->assertEquals('vendor/bin', $autoloadUtil->getBinFolder());
+    }
+
+    public function testGetBinFolderReturnsCustomBinDir(): void
+    {
+        file_put_contents($this->tempComposerFile, json_encode(['config' => ['bin-dir' => 'custom/bin']]));
+        $autoloadUtil = new AutoloadUtil($this->tempComposerFile);
+
+        $this->assertEquals('custom/bin', $autoloadUtil->getBinFolder());
+    }
+
+    public function testGetBinFolderThrowsExceptionForMissingComposerFile(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to find composer.json');
+
+        $autoloadUtil = new AutoloadUtil('/nonexistent/composer.json');
+        $autoloadUtil->getBinFolder();
+    }
+
+    public function testGetBinFolderThrowsExceptionForInvalidComposerContent(): void
+    {
+        file_put_contents($this->tempComposerFile, 'invalid json');
+        $autoloadUtil = new AutoloadUtil($this->tempComposerFile);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid composer.json file');
+
+        $autoloadUtil->getBinFolder();
+    }
+}


### PR DESCRIPTION
The commit introduces a new utility to dynamically resolve the Composer bin folder path by reading the project's composer.json file. This utility is integrated into the to improve PHPStan executable discovery by adding a new candidate based on the Composer bin-dir configuration. The method returns the custom bin folder if configured, otherwise defaults to . This improves compatibility with projects that use custom bin-dir configurations in Composer. `AutoloadUtil``PHPStanRunner``getBinFolder()``vendor/bin`
