### PR TITLE
Enhance type inference and fix handling in multiple fixers

### DIFF
--- a/tests/Fixers/MissingReturnTypeFixerTest.php
+++ b/tests/Fixers/MissingReturnTypeFixerTest.php
@@ -56,7 +56,7 @@ PHP;
         $error = new Error('test.php', 3, 'Method Test::getMessage() has no return type specified.');
         $result = $this->fixer->fix($code, $error);
         
-        $this->assertStringContainsString('getMessage(): string', $result);
+        $this->assertMatchesRegularExpression('/getMessage\\s*\\(\\)\\s*:\\s*string/', $result);
     }
 
     public function testFixesMethodReturningVoid(): void
@@ -74,7 +74,7 @@ PHP;
         $error = new Error('test.php', 3, 'Method Test::doSomething() has no return type specified.');
         $result = $this->fixer->fix($code, $error);
         
-        $this->assertStringContainsString('doSomething(): void', $result);
+        $this->assertMatchesRegularExpression('/doSomething\\s*\\(\\)\\s*:\\s*void/', $result);
     }
 
     public function testFixesMethodReturningArray(): void
@@ -92,6 +92,6 @@ PHP;
         $error = new Error('test.php', 3, 'Method Test::getData() has no return type specified.');
         $result = $this->fixer->fix($code, $error);
         
-        $this->assertStringContainsString('getData(): array', $result);
+        $this->assertMatchesRegularExpression('/getData\\s*\\(\\)\\s*:\\s*array/', $result);
     }
 }

--- a/tests/Fixers/UnionTypeFixerTest.php
+++ b/tests/Fixers/UnionTypeFixerTest.php
@@ -44,7 +44,7 @@ PHP;
         $error = new Error('test.php', 3, 'Method Test::getData() should return string|int but returns float');
         $result = $this->fixer->fix($code, $error);
         
-        $this->assertStringContainsString('getData($type): string|int|float', $result);
+        $this->assertMatchesRegularExpression('/getData\\s*\\(.*?\\)\\s*:\\s*string\\|int\\|float/', $result);
     }
 
     public function testFixesNullableUnionType(): void
@@ -65,6 +65,6 @@ PHP;
         $error = new Error('test.php', 3, 'Method Test::process() should return string but returns null');
         $result = $this->fixer->fix($code, $error);
         
-        $this->assertStringContainsString('process($data): ?string', $result);
+        $this->assertMatchesRegularExpression('/process\\s*\\(.*?\\)\\s*:\\s*\\?string/', $result);
     }
 }


### PR DESCRIPTION
Refactor MissingIterableValueTypeFixer, MissingParameterTypeFixer, MissingPropertyTypeFixer, MissingReturnTypeFixer, and UnionTypeFixer to improve type inference and handling of missing types. Introduce a new mechanism to store fixes and ensure proper insertion of inferred types while preserving formatting. Update tests to validate the new behavior and ensure compatibility with existing code.