### PR TITLE
Refactor MissingIterableValueTypeFixer and MissingReturnTypeFixer to improve array type handling

### DIFF
--- a/src/Fixers/MissingIterableValueTypeFixer.php
+++ b/src/Fixers/MissingIterableValueTypeFixer.php
@@ -160,7 +160,7 @@ class MissingIterableValueTypeFixer extends AbstractFixer
                 if (strpos($docText, '@var') !== false) {
                     // Update existing @var tag
                     $docText = preg_replace(
-                        '/@var\s+array\b/',
+                        '/@var\s+array(?!\<)/',
                         '@var ' . $arrayType,
                         $docText
                     );
@@ -196,7 +196,7 @@ class MissingIterableValueTypeFixer extends AbstractFixer
                 if (strpos($docText, '@return') !== false) {
                     // Update existing @return tag
                     $docText = preg_replace(
-                        '/@return\s+array\b/',
+                        '/@return\s+array(?!\<)/',
                         '@return ' . $arrayType,
                         $docText
                     );

--- a/src/Fixers/MissingReturnTypeFixer.php
+++ b/src/Fixers/MissingReturnTypeFixer.php
@@ -416,10 +416,10 @@ class MissingReturnTypeFixer extends AbstractFixer
                 
                 if (!empty($docText)) {
                     // Check if @return already exists
-                    if (preg_match('/@return\s+array\b/', $docText)) {
+                    if (preg_match('/@return\s+array(?!\<)/', $docText)) {
                         // Update existing @return
                         $docText = preg_replace(
-                            '/@return\s+array\b/',
+                            '/@return\s+array(?!\<)/',
                             '@return ' . $arrayType,
                             $docText
                         );


### PR DESCRIPTION
Update regex patterns in both fixers to ensure accurate detection and replacement of @var and @return tags for array types, preventing false matches with generic array declarations. This enhancement improves PHPDoc generation and type inference consistency across the codebase.